### PR TITLE
Player leaderboard fix

### DIFF
--- a/Typeracer/Context/AppDbContext.cs
+++ b/Typeracer/Context/AppDbContext.cs
@@ -35,6 +35,16 @@ public class AppDbContext : DbContext
 
         modelBuilder.Entity<Player>()
             .HasKey(p => p.PlayerID);
+        
+        modelBuilder.Entity<Player>()
+            .HasMany(p => p.WPMs)
+            .WithOne()
+            .HasForeignKey(w => w.PlayerId);
+
+        modelBuilder.Entity<Player>()
+            .HasMany(p => p.Accuracies)
+            .WithOne()
+            .HasForeignKey(a => a.PlayerId);
 
         modelBuilder.Entity<Game>()
             .HasKey(g => g.GameId);

--- a/Typeracer/Controllers/LeaderboardController.cs
+++ b/Typeracer/Controllers/LeaderboardController.cs
@@ -94,10 +94,32 @@ namespace Typeracer.Controllers
             {
                 try
                 {
-                    Player? existingPlayer = context.Players.Find(player.PlayerID);
+                    //Player? existingPlayer = context.Players.Find(player.PlayerID);
+                    Player? existingPlayer = context.Players
+                        .Include(p => p.WPMs)
+                        .Include(p => p.Accuracies)
+                        .FirstOrDefault(p => p.Username == player.Username);
                     if (existingPlayer == null)
                     {
                         context.Players.Add(player);
+                        context.SaveChanges();
+                    }
+                    else
+                    {
+                        player = existingPlayer;
+                        WPM newWPM = new WPM
+                        {
+                            Value = playerData.BestWPM, PlayerId = existingPlayer.PlayerID
+                        };
+        
+                        Accuracy newAccuracy = new Accuracy
+                        {
+                            Value = playerData.BestAccuracy, PlayerId = existingPlayer.PlayerID
+                        };
+
+
+                        context.Wpms.Add(newWPM);
+                        context.Accuracies.Add(newAccuracy);
                         context.SaveChanges();
                     }
 


### PR DESCRIPTION
When adding data, comparisons are made using the username, instead of player-id. This makes the newly implemented interactive leaderboard useful.