### PR TITLE
Fixing "pradėti iš naujo" button

### DIFF
--- a/Typeracer/Controllers/StatisticsController.cs
+++ b/Typeracer/Controllers/StatisticsController.cs
@@ -54,7 +54,7 @@ public class StatisticsController : ControllerBase
             data.BeginningTimestampWord = DateTime.SpecifyKind(data.BeginningTimestampWord, DateTimeKind.Utc);
             data.EndingTimestampWord = DateTime.SpecifyKind(data.EndingTimestampWord, DateTimeKind.Utc);
         }
-
+        
         // initiating a game object with all the statistics data
         Game game = new Game(statisticsData);
         _context.Games.Add(game);

--- a/Typeracer/src/components/Type.js
+++ b/Typeracer/src/components/Type.js
@@ -61,7 +61,7 @@ function Type() {
             wordsInfoRef.current = tempWordsInfo;
         }
     };
-
+    
     const fetchParagraphText = async () => {
         let response = await fetch('/Home/GetParagraphText/');
         let jsonResponse = await response.json();
@@ -72,9 +72,7 @@ function Type() {
         setTypingText(paragraphText);
         setInitialText(paragraphText);
         buildWordsInfo(paragraphText);
-
-        // Calculating the total amount of words and characters
-        const totalWords = paragraphText.trim().split(/\s+/).length;
+        
         setStatisticsData(prevData => ({
             ...prevData,
             ParagraphId: paragraphId,
@@ -84,7 +82,7 @@ function Type() {
         // Creating wordsInfoRef
         if (paragraphText) {
             createWordsInfoRef(paragraphText);
-       }
+        }
     };
     
     const createWordsInfoRef = (paragraphText) => {
@@ -368,10 +366,14 @@ function Type() {
     };
 
     const resetStateForRestartButton = () => {
+        const prevParagraph = statisticsData.Paragraph;
+        const prevParagraphId = statisticsData.ParagraphId;
+        
         setStatisticsData({
             LocalStartTime: null,
             LocalFinishTime: null,
-            Paragraph: statisticsData.Paragraph,
+            ParagraphId: prevParagraphId,
+            Paragraph: prevParagraph,
             TypedAmountOfWords: 0,
             TypedAmountOfCharacters: 0,
             NumberOfWrongfulCharacters: 0,
@@ -388,6 +390,8 @@ function Type() {
     }
 
     const resetStateForNextTextButton = () => {
+        
+        
         setStatisticsData({
             LocalStartTime: null,
             LocalFinishTime: null,


### PR DESCRIPTION
Fixing a bug where after pressing the "pradėti iš naujo" button the statistics data would not send the paragraph id